### PR TITLE
Fixed 404 in config.vm.box_url

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure('2') do |config|
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = 'http://cloud-images.ubuntu.com/vagrant/trusty/current/trustu-server-cloudimg-amd64-vagrant-disk1.box'
+  config.vm.box_url = 'http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box'
 
   config.vm.provider :virtualbox do |vb|
     # Use VBoxManage to customize the VM. For example to change memory:


### PR DESCRIPTION
 box_url has been corrected to successfully point to the correct vagrant box.