### PR TITLE
Allow custom data_dir for MySQL

### DIFF
--- a/recipes/database_mysql.rb
+++ b/recipes/database_mysql.rb
@@ -9,6 +9,7 @@ mysql_service 'default' do
   version '5.6'
   bind_address node[:bamboo][:database][:host]
   port '3306'
+  data_dir node[:mysql][:data_dir] if node[:mysql][:data_dir]
   initial_root_password node[:mysql][:server_root_password]
   action [:create, :start]
 end


### PR DESCRIPTION
I was using the previous versions of the cookbook, which used the older `mysql::server` recipe. I had a custom `mysql[:data_dir]` set. This should allow for seamless upgrades from `<= 1.3.0` to `> 1.3.0` without breaking the database.