### PR TITLE
Bumps backup version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ end
 depends 'apt'
 depends 'ark',                '~> 0.9.0'
 depends 'apache2'
-depends 'backup',             '~> 0.2.1'
+depends 'backup',             '~> 0.3.0'
 depends 'cron',               '~> 1.2.8'
 depends 'database',           '~> 3.0.0'
 depends 'git',                '~> 2.7.0'


### PR DESCRIPTION
> Unable to satisfy constraints on package bamboo due to solution constraint (bamboo = 1.4.0). Solution constraints that may result in a constraint on bamboo: [(bamboo = 1.4.0)]
Demand that cannot be met: (bamboo = 1.4.0)

It looks like there are no `backup` versions able to satisfy the current constraint `~> 0.2.1`. As you can see [here](https://supermarket.chef.io/cookbooks/backup), the contiguous versions are `0.0.4` and `0.3.1`.