### PR TITLE
Specify proper mysql-client version for mysql2_chef_gem

### DIFF
--- a/recipes/database_mysql.rb
+++ b/recipes/database_mysql.rb
@@ -7,6 +7,7 @@ database_connection = {
 
 include_recipe 'build-essential'
 mysql2_chef_gem 'default' do
+  client_version node[:bamboo][:database][:version]
   action :install
 end
 


### PR DESCRIPTION
Right now, installing a nonstandard version of mysql will result in
`mysql2_chef_gem` resource installing the standard mysql-client package, then
the mysql_service resource installing the correct mysql-server package, which
happens to uninstall the bad mysql-client version in the process. This might
have odd effects if the mysql2 gem install process varies based on the mysql
package that's installed when it compiles.