### PR TITLE
Remove patch-level from version constraints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,12 @@ MethodLength:
 SingleSpaceBeforeFirstArg:
   Enabled: false
 #
+# group of `depends` have some lone lines that we want aligned to group
+#
+ExtraSpacing:
+  Exclude:
+    - metadata.rb
+#
 # couldn't figure it out so set this
 #
 ClassAndModuleChildren:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,7 +69,7 @@ default[:bamboo][:agent][:group]                  = 'bamboo'                    
 default[:bamboo][:agent][:user_home]              = '/home/bamboo'                      # bamboo system user home directory
 default[:bamboo][:agent][:disable_agent_auto_capability_detection] = true
 default[:bamboo][:agent][:additional_path]        = ''
-default[:bamboo][:agent_capabilities]              = {}
+default[:bamboo][:agent_capabilities]             = {}
 
 # If you're authenticating against a Crowd server you can use this authenticator for single sign-on.
 # Enable it after configuring your Crowd properties through user management and restart Bamboo. It does not support

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,15 +16,15 @@ end
 
 # Always specify the version of your dependencies
 depends 'apt'
-depends 'ark',                '~> 0.9.0'
+depends 'ark',                '~> 0.9'
 depends 'apache2'
 depends 'backup',             '= 0.2.4'
 depends 'cron'
-depends 'database',           '~> 4.0.6'
+depends 'database',           '~> 4.0'
 depends 'git'
 depends 'java'
 depends 'mysql',              '~> 6.0'
-depends 'mysql_connector',    '~> 0.7.2'
+depends 'mysql_connector',    '~> 0.7'
 depends 'perl'
 depends 'mysql2_chef_gem',    '~> 1.0'
 depends 'build-essential'

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -28,7 +28,7 @@ user node[:bamboo][:agent][:user] do
   gid  node[:bamboo][:agent][:group]
   home node[:bamboo][:agent][:user_home]
   supports :manage_home => true
-  shell  '/bin/bash'
+  shell '/bin/bash'
   system  true
   action  :create
 end

--- a/resources/agent_capability.rb
+++ b/resources/agent_capability.rb
@@ -7,4 +7,4 @@ actions :add, :remove
 default_action :add
 
 attribute :name, kind_of: String, name_attribute: true
-attribute :value,  kind_of: String, required: true
+attribute :value, kind_of: String, required: true


### PR DESCRIPTION
As per your comments in #23, only submitting changes for non-backup cookbooks.

Uses pessimistic version constraint only on minor level, not patch, as major-level version bumps are the breaking ones to be cautious with.