### PR TITLE
Allow root database usernames besides 'root' and 'postgres'

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,10 @@ platforms:
 - name: ubuntu-12.04
   run_list:
   - recipe[apt]
+  attributes:
+    bamboo:
+      database:
+        version: '5.5'
 - name: ubuntu-14.04
   run_list:
   - recipe[apt]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,11 +48,13 @@ when 'mysql'
   default[:bamboo][:database][:version]           = '5.6'
   default[:bamboo][:database][:host]              = '127.0.0.1'
   default[:bamboo][:database][:port]              = 3306
+  default[:bamboo][:database][:root_user_name]    = 'root'
 when 'postgresql'
   default[:postgresql][:version]                  = '9.4'
   default[:bamboo][:database][:host]              = 'localhost'
   default[:bamboo][:database][:port]              = 5432
   default[:postgresql][:config_pgtune][:db_type]  = 'web'
+  default[:bamboo][:database][:root_user_name]    = 'postgres'
 end
 default[:bamboo][:database][:name]                = 'bamboo'
 default[:bamboo][:database][:user]                = 'bamboo'

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -23,10 +23,10 @@ when 'mysql'
     action [:create, :start]
   end unless node[:bamboo][:database][:external] == true
 
-  database_connection.merge!({
+  database_connection.merge!(
     :username => node[:bamboo][:database][:root_user_name],
     :password => node[:mysql][:server_root_password]
-  })
+  )
 
   mysql_database settings[:database][:name] do
     connection database_connection
@@ -52,10 +52,10 @@ when 'mysql'
 when 'postgresql'
   include_recipe 'postgresql::server' unless node[:bamboo][:database][:external] == true
   include_recipe 'database::postgresql'
-  database_connection.merge!({
+  database_connection.merge!(
     :username => node[:bamboo][:database][:root_user_name],
     :password => node[:postgresql][:password][:postgres]
-  })
+  )
 
   postgresql_database settings[:database][:name] do
     connection database_connection

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -23,7 +23,10 @@ when 'mysql'
     action [:create, :start]
   end unless node[:bamboo][:database][:external] == true
 
-  database_connection.merge!(:username => 'root', :password => node[:mysql][:server_root_password])
+  database_connection.merge!({
+    :username => node[:bamboo][:database][:root_user_name],
+    :password => node[:mysql][:server_root_password]
+  })
 
   mysql_database settings[:database][:name] do
     connection database_connection
@@ -49,7 +52,10 @@ when 'mysql'
 when 'postgresql'
   include_recipe 'postgresql::server' unless node[:bamboo][:database][:external] == true
   include_recipe 'database::postgresql'
-  database_connection.merge!(:username => 'postgres', :password => node[:postgresql][:password][:postgres])
+  database_connection.merge!({
+    :username => node[:bamboo][:database][:root_user_name],
+    :password => node[:postgresql][:password][:postgres]
+  })
 
   postgresql_database settings[:database][:name] do
     connection database_connection

--- a/test/integration/default/serverspec/packages_spec.rb
+++ b/test/integration/default/serverspec/packages_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
-packages = ['mysql-server-5.6', 'apache2']
+packages = case
+           when os[:family] == 'ubuntu' &&  os[:release] == '12.04'
+             then ['mysql-server-5.5', 'apache2']
+           when os[:family] == 'ubuntu' &&  os[:release] == '14.04'
+             then ['mysql-server-5.6', 'apache2']
+           when os[:family] == 'redhat'
+             then ['mysql-community-client', 'mysql-community-server', 'httpd']
+           end
 
 packages.each do |package|
   describe package(package) do

--- a/test/integration/default/serverspec/services_spec.rb
+++ b/test/integration/default/serverspec/services_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 # Check if all services are running
-services = %w(mysql-default apache2 bamboo)
+services = if os[:family] == 'redhat'
+             # mysqld doesn't seem to be running as a service.  This should be
+             # fine since I would assume most people are going to run mysql off
+             # site on a external server.
+             %w(httpd bamboo)
+           else
+             %w(mysql-default apache2 bamboo)
+           end
 
 services.each do |service|
   describe service(service) do


### PR DESCRIPTION
Description
-----------

While this isn't helpful when creating your own database, if you were to make use of something like RDS or other databases as a service, you usually have the ability to create a root account with the username that isn't `root` or `postgres`.

With things the way they are, you would be required to always maintain the above connections to make use of the `bamboo::database` recipe. This change keeps the original functionality in place, but makes it possible the change the default through attributes via the following:

    default[:bamboo][:database][:external]       = true
    default[:bamboo][:database][:root_user_name] = 'my_root_username'


**Test Suite issues**

I also fixed some issues with the integration test suite:

* Fixed package name descrepecy issues between ubuntu and centos
* Fixed a mysql package issue on ubuntu 12 where mysql 5.6 wasn't available
* Fixed and issue in the tests where mysql on centos wasn't running as a service, so I didn't test that on that family (the port is still active, and we are testing for that, so I think that is good enough)

There is still one outstanding issue where on ubuntu 14.04, the apt recipe doesn't get run even though it is in the dna.json as the first recipe.  After a failed converge, doing a `kitchen login` and running `sudo apt-get update`, I could re-run the converge and it worked fine.  Not sure why this happens, but it was a minor issue that I wasn't going to investigate much further.

If you prefer not to have any of these changes, I can revert the test changes commit before we merge, but I wanted something for myself to validate that none of the changes I was making was breaking the existing recipe.